### PR TITLE
Double buffer and camera thread

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,18 @@ ifeq ($(QPU), 1)
 endif
 
 ifeq ($(WIRING), 1)
-	LDFLAGS += -lwiringPi
 	CCXFLAGS += -DWIRING_PI=1
+	LDFLAGS  += -lwiringPi
+endif
+
+ifeq ($(CAM), 1) 
+	CCXFLAGS += -DRASPICAM=1
+	LDFLAGS  += -lraspicam
+endif
+
+ifeq ($(OPENCV), 1)
+	CCXFLAGS += -DOPENCV=1
+	LDFLAGS  += -lopencv_core -lopencv_imgcodecs 
 endif
 
 # Find all subdirectories
@@ -43,7 +53,7 @@ $(OBJSDIR):
 	mkdir build
 
 all:
-	make WIRING=1 QPU=1
+	make WIRING=1 QPU=1 CAM=1 OPENCV=1
 
 clean:
 	cd ./include/QPULib && make clean

--- a/src/defs.hpp
+++ b/src/defs.hpp
@@ -3,6 +3,7 @@
 
 #define IO_THREAD_NAME "IO Thread"
 #define IR_THREAD_NAME "IR Thread"
+#define CAM_THREAD_NAME "Camera Thread"
 #define NET_THREAD_NAME "Network Thread"
 #define MAIN_THREAD_NAME "Main Thread"
 

--- a/src/image_recognition/camera_thread.cpp
+++ b/src/image_recognition/camera_thread.cpp
@@ -25,6 +25,8 @@ void camera_thread_main(const std::atomic_bool& running, double_buffer& image_bu
         std::this_thread::sleep_for(std::chrono::seconds(3));
     #endif
 
+    image_buffer.lock_write_buffer();
+
     while (running) {
 
         // Waits until the most recent captured image starts being processed
@@ -40,5 +42,7 @@ void camera_thread_main(const std::atomic_bool& running, double_buffer& image_bu
 
         #endif
     }
+
+    image_buffer.unlock_write_buffer();
 
 }

--- a/src/image_recognition/camera_thread.cpp
+++ b/src/image_recognition/camera_thread.cpp
@@ -1,0 +1,17 @@
+
+#include "camera_thread.hpp"
+
+
+void camera_thread_main(const std::atomic_bool& running, double_buffer& image_buffer) {
+
+    while (running) {
+
+        // Waits until the most recent captured image starts being processed
+        // before taking a new one. This function should in theory be enough
+        // to handle the lock for the write buffer
+        image_buffer.wait_for_image();
+        
+        // Write image to buffer
+    }
+
+}

--- a/src/image_recognition/camera_thread.cpp
+++ b/src/image_recognition/camera_thread.cpp
@@ -15,7 +15,10 @@ void camera_thread_main(const std::atomic_bool& running, double_buffer& image_bu
     #ifdef _RaspiCam_H_
         raspicam::RaspiCam camera;
 
-        // image_buffer = double_buffer(camera.getImageTypeSize(raspicam::RASPICAM_FORMAT_RGB));
+        camera.setWidth(IMAGE_WIDTH);
+        camera.setHeight(IMAGE_HEIGHT);
+
+        image_buffer.resize(camera.getImageTypeSize(raspicam::RASPICAM_FORMAT_RGB));
 
         if (!camera.open()) queue_message("Failed to open camera.");
 

--- a/src/image_recognition/camera_thread.cpp
+++ b/src/image_recognition/camera_thread.cpp
@@ -15,7 +15,7 @@ void camera_thread_main(const std::atomic_bool& running, double_buffer& image_bu
     #ifdef _RaspiCam_H_
         raspicam::RaspiCam camera;
 
-        image_buffer = double_buffer(camera.getImageTypeSize(raspicam::RASPICAM_FORMAT_RGB));
+        // image_buffer = double_buffer(camera.getImageTypeSize(raspicam::RASPICAM_FORMAT_RGB));
 
         if (!camera.open()) queue_message("Failed to open camera.");
 

--- a/src/image_recognition/camera_thread.cpp
+++ b/src/image_recognition/camera_thread.cpp
@@ -1,8 +1,26 @@
 
 #include "camera_thread.hpp"
 
+#include <thread>
+#include <chrono>
+
+#ifdef RASPICAM
+    #include <raspicam/raspicam.h>
+#endif
+
+#include "logging.hpp"
 
 void camera_thread_main(const std::atomic_bool& running, double_buffer& image_buffer) {
+    
+    #ifdef _RaspiCam_H_
+        raspicam::RaspiCam camera;
+
+        image_buffer = double_buffer(camera.getImageTypeSize(raspicam::RASPICAM_FORMAT_RGB));
+
+        if (!camera.open()) queue_message("Failed to open camera.");
+
+        std::this_thread::sleep_for(std::chrono::seconds(3));
+    #endif
 
     while (running) {
 
@@ -12,6 +30,12 @@ void camera_thread_main(const std::atomic_bool& running, double_buffer& image_bu
         image_buffer.wait_for_image();
         
         // Write image to buffer
+        #ifdef _RaspiCam_H_
+
+            camera.grab();
+            camera.retrieve(image_buffer.get_write_buffer(), raspicam::RASPICAM_FORMAT_RGB);
+
+        #endif
     }
 
 }

--- a/src/image_recognition/camera_thread.hpp
+++ b/src/image_recognition/camera_thread.hpp
@@ -4,7 +4,8 @@
 #include <atomic>
 #include "double_buffer.hpp"
 
-#define IMAGE_SIZE 1024
+#define IMAGE_WIDTH   320
+#define IMAGE_HEIGHT  240
 
 void camera_thread_main(const std::atomic_bool& running, double_buffer& image_buffer);
 

--- a/src/image_recognition/camera_thread.hpp
+++ b/src/image_recognition/camera_thread.hpp
@@ -1,0 +1,11 @@
+#ifndef CM_CAMERA_THREAD_H
+#define CM_CAMERA_THREAD_H
+
+#include <atomic>
+#include "double_buffer.hpp"
+
+#define IMAGE_SIZE 1024
+
+void camera_thread_main(const std::atomic_bool& running, double_buffer& image_buffer);
+
+#endif

--- a/src/image_recognition/double_buffer.cpp
+++ b/src/image_recognition/double_buffer.cpp
@@ -6,8 +6,10 @@
 
 #ifdef SHARED_ENABLED
 
-double_buffer::double_buffer(uint32_t size) : buffer_1(size), buffer_2(size) {
+double_buffer::double_buffer(uint32_t size) /*: buffer_1(size), buffer_2(size) */ {
 
+    buffer_1 = SharedArray<uint8_t>(size);
+    buffer_2 = SharedArray<uint8_t>(size);
     read_buffer = &buffer_1;
     write_buffer = &buffer_2;
 

--- a/src/image_recognition/double_buffer.cpp
+++ b/src/image_recognition/double_buffer.cpp
@@ -1,0 +1,101 @@
+
+#include "double_buffer.hpp"
+
+#include <algorithm>
+#include <mutex>
+
+#ifdef SHARED_ENABLED
+
+double_buffer::double_buffer(uint32_t size) : buffer_1(size), buffer_2(size) {
+
+    read_buffer = &buffer_1;
+    write_buffer = &buffer_2;
+
+}
+
+#else
+
+double_buffer::double_buffer(uint32_t size) {
+
+    read_buffer = new uint8_t[size]();
+    write_buffer = new uint8_t[size]();
+}
+
+#endif
+
+
+double_buffer::~double_buffer() {
+
+    #ifdef SHARED_ENABLED
+        read_buffer = nullptr;
+        write_buffer = nullptr;
+        buffer_1.dealloc();
+        buffer_2.dealloc();
+    #else
+        delete[] read_buffer;
+        delete[] write_buffer;
+    #endif
+
+}
+
+uint8_t double_buffer::read(uint32_t index) {
+
+    #ifdef SHARED_ENABLED
+        return (*read_buffer)[index];
+    #else
+        return read_buffer[index];
+    #endif
+
+}
+
+void double_buffer::write(uint32_t index, uint8_t value) {
+
+    #ifdef SHARED_ENABLED
+        (*write_buffer)[index] = value;
+    #else
+        write_buffer[index] = value;
+    #endif
+
+}
+
+const uint8_t* double_buffer::get_read_buffer() {
+
+    #ifdef SHARED_ENABLED
+        return read_buffer->getPointer();
+    #else
+        return read_buffer;
+    #endif
+}
+
+uint8_t* double_buffer::get_write_buffer() {
+
+    #ifdef SHARED_ENABLED
+        return write_buffer->getPointer();
+    #else
+        return write_buffer;
+    #endif
+}
+
+void double_buffer::swap_buffers() {
+
+    write_lock.lock();
+
+    std::swap(read_buffer, write_buffer);
+    image_processed = true;
+
+    write_lock.unlock();
+    new_image_condition.notify_one();
+
+}
+
+void double_buffer::wait_for_image() {
+
+    // Create unique lock from writer lock without locking it, since it is already locked by this thread
+    std::unique_lock lock(write_lock, std::adopt_lock);
+    new_image_condition.wait(lock, [this]{ return this->image_processed.load(); });
+    
+    image_processed = false;
+
+    // Release association with the writer_lock, note that it is still locked after this
+    lock.release();
+}

--- a/src/image_recognition/double_buffer.cpp
+++ b/src/image_recognition/double_buffer.cpp
@@ -98,6 +98,14 @@ uint8_t* double_buffer::get_write_buffer() {
     #endif
 }
 
+void double_buffer::lock_write_buffer() {
+    write_lock.lock();
+}
+
+void double_buffer::unlock_write_buffer() {
+    write_lock.unlock();
+}
+
 void double_buffer::swap_buffers() {
 
     write_lock.lock();

--- a/src/image_recognition/double_buffer.hpp
+++ b/src/image_recognition/double_buffer.hpp
@@ -1,0 +1,113 @@
+#ifndef CM_DOUBLE_BUFFER_H
+#define CM_DOUBLE_BUFFER_H
+
+#include <cstdint>
+#include <atomic>
+#include <mutex>
+#include <condition_variable>
+
+#ifdef QPULIB
+    #include "QPULib.h"
+#endif
+
+#ifdef _QPULIB_H_
+    #define SHARED_ENABLED
+#endif
+
+/**
+ * A double buffer class used to allow synchronous image reading and writing
+ */
+class double_buffer {
+
+public:
+
+    /**
+     * Constructor that creates a double_buffer with a given size
+     * 
+     * @param size The size of the buffer in bytes
+     */
+    double_buffer(uint32_t size);
+
+    /**
+     * Destructor
+     */
+    ~double_buffer();
+
+    /**
+     * Reads a byte from the read-only buffer
+     * 
+     * @param index The index to read from
+     */
+    uint8_t read(uint32_t index);
+
+    /**
+     * Writes a byte to the write-only buffer
+     * 
+     * @param index The index to write to
+     * @param value The value to write
+     */
+    void write(uint32_t index, uint8_t value);
+
+    /**
+     * @return Constant pointer to the read-only buffer
+     */
+    const uint8_t* get_read_buffer();
+
+    /**
+     * @return Pointer to the write-only buffer
+     */
+    uint8_t* get_write_buffer();
+
+    /**
+     * Swaps the read and write buffers
+     */
+    void swap_buffers();
+
+    /**
+     * Calling this function blocks the calling thread until swap_buffers is called.
+     * NOTE: Keeps the write buffer locked, make sure to unlock it when you are done
+     */
+    void wait_for_image();
+
+
+private:
+
+    /**
+     * Explicitly deleted default constructor and copy and move semantics
+     */
+    double_buffer() = delete;
+    double_buffer(const double_buffer& other) = delete;
+    double_buffer(double_buffer&& other) = delete;
+    double_buffer& operator=(const double_buffer& other) = delete;
+    double_buffer& operator=(double_buffer&& other) = delete;
+
+    // Locks the write buffer 
+    std::mutex write_lock;
+
+    // Condition that wakes up camera thread when the image has been processed
+    std::condition_variable new_image_condition;
+
+    // Flag for new image
+    std::atomic_bool image_processed;
+
+    #ifdef SHARED_ENABLED
+
+        // Buffers are shared with the GPU
+        SharedArray<uint8_t> buffer_1;
+        SharedArray<uint8_t> buffer_2;
+        
+        // Pointers to the shared buffers to allow swapping
+        SharedArray<uint8_t>* read_buffer;
+        SharedArray<uint8_t>* write_buffer;
+
+    #else
+        
+        // CPU Only buffers
+        uint8_t* read_buffer;
+        uint8_t* write_buffer;
+
+    #endif
+
+};
+
+#endif

--- a/src/image_recognition/double_buffer.hpp
+++ b/src/image_recognition/double_buffer.hpp
@@ -66,6 +66,16 @@ public:
     uint8_t* get_write_buffer();
 
     /**
+     * Locks the mutex associated with the write_buffer
+     */
+    void lock_write_buffer();
+
+    /**
+     * Unlocks the mutex associated with the write_buffer
+     */
+    void unlock_write_buffer();
+
+    /**
      * Swaps the read and write buffers
      */
     void swap_buffers();

--- a/src/image_recognition/double_buffer.hpp
+++ b/src/image_recognition/double_buffer.hpp
@@ -34,11 +34,18 @@ public:
     ~double_buffer();
 
     /**
+     * Resizes the double buffer to the new size
+     * 
+     * @param new_size The new size of the double buffer
+     */
+    void resize(uint32_t new_size);
+
+    /**
      * Reads a byte from the read-only buffer
      * 
      * @param index The index to read from
      */
-    uint8_t read(uint32_t index);
+    uint8_t read(uint32_t index) const;
 
     /**
      * Writes a byte to the write-only buffer
@@ -51,7 +58,7 @@ public:
     /**
      * @return Constant pointer to the read-only buffer
      */
-    const uint8_t* get_read_buffer();
+    const uint8_t* get_read_buffer() const;
 
     /**
      * @return Pointer to the write-only buffer

--- a/src/image_recognition/image_recognition.cpp
+++ b/src/image_recognition/image_recognition.cpp
@@ -5,9 +5,13 @@
 #include <chrono>
 
 #include "logging.hpp"
+#include "double_buffer.hpp"
 
-void image_recognition_main(const std::atomic_bool& running) {
-    
+void image_recognition_main(const std::atomic_bool& running, double_buffer& image_buffer) {
+
+    // Swap the buffers to notify camera thread to grab image
+    image_buffer.swap_buffers();
+
     // Main loop
     while (running) {
 

--- a/src/image_recognition/image_recognition.hpp
+++ b/src/image_recognition/image_recognition.hpp
@@ -3,9 +3,11 @@
 
 #include <atomic>
 
+#include "double_buffer.hpp"
+
 /**
  * Main function ran by the image recognition thread
  */
-void image_recognition_main(const std::atomic_bool& running);
+void image_recognition_main(const std::atomic_bool& running, double_buffer& image_buffer);
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,27 +9,45 @@
 #include "logging.hpp"
 #include "defs.hpp"
 #include "network.hpp"
+#include "double_buffer.hpp"
+#include "camera_thread.hpp"
 
 int main() {
     
+    // Create global running variable
     std::atomic_bool running = true;
 
-    std::thread io_thread(io_thread_main, std::ref(running));
-    std::thread ir_thread(image_recognition_main, std::ref(running));
-    std::thread net_thread(network_thread_main, std::ref(running));
+    // Create image buffer for image processing
+    double_buffer image_buffer(IMAGE_SIZE);
 
+    // Create IO thread for communication with steering and sensor modules
+    std::thread io_thread(io_thread_main, std::ref(running));
+
+    // Create network thread for communication with remote module
+    std::thread net_thread(network_thread_main, std::ref(running));
+    
+    // Create camera thread for capturing images
+    std::thread cam_thread(camera_thread_main, std::ref(running), std::ref(image_buffer));
+    
+    // Create image recognition thread for image processing
+    std::thread ir_thread(image_recognition_main, std::ref(running), std::ref(image_buffer));
+
+    // Store name for each thread so logging thread knows where messages come from
     std::unordered_map<std::thread::id, std::string> thread_name_map;
     thread_name_map.insert({io_thread.get_id(), IO_THREAD_NAME});
     thread_name_map.insert({ir_thread.get_id(), IR_THREAD_NAME});
     thread_name_map.insert({net_thread.get_id(), NET_THREAD_NAME});
+    thread_name_map.insert({cam_thread.get_id(), CAM_THREAD_NAME});
     thread_name_map.insert({std::this_thread::get_id(), MAIN_THREAD_NAME});
 
+    // Create logging thread for printing to stdout and log file
     std::thread logging_thread(logging_thread_main, std::ref(thread_name_map), std::ref(running));
 
     // running = false;
 
     io_thread.join();
     ir_thread.join();
+    cam_thread.join();
     net_thread.join();
     logging_thread.join();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,7 +18,7 @@ int main() {
     std::atomic_bool running = true;
 
     // Create image buffer for image processing
-    double_buffer image_buffer(IMAGE_SIZE);
+    double_buffer image_buffer(1024);
 
     // Create IO thread for communication with steering and sensor modules
     std::thread io_thread(io_thread_main, std::ref(running));


### PR DESCRIPTION
# Double buffer and camera thread

* Implemented synchronous double buffer that allows writing to one buffer and reading from another from different threads.
* Implemented first draft of camera thread that captures images and writes it into a double buffer shared with the image recognition thread.
* Added makefile options for all libraries. (QPU=1, CAM=1, WIRING=1 & OPENCV=1) Running "make all" will compile with all libraries.

## Relevant issues

#6 

## Testing

Needs to be live tested on the raspberry pi with a camera.