### PR TITLE
Added option to compile qpulib in emulation mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,24 @@
 CCX=clang++
 CCXFLAGS = -std=c++17 -pthread 
 LDFLAGS :=
+QPUFLAGS :=
 
 SRCDIR  = ./src
 OBJSDIR = ./build
 DEPDIR	= ./include
 GPUDIR = ./include/QPULib/Lib
+
 QPULIB :=
 
 ifeq ($(QPU), 1)
-	CCXFLAGS += -DQPU_MODE
+	CCXFLAGS += -DQPU_MODE -DQPU
 	QPULIB := ./include/QPULib/qpulib.a
+endif
+
+ifeq ($(QPUE), 1)
+	CCXFLAGS += -DEMULATION_MODE -DQPU
+	QPULIB := ./include/QPULib/qpulib.a
+	QPUFLAGS += EMU=1
 endif
 
 ifeq ($(WIRING), 1)
@@ -47,7 +55,7 @@ $(OBJECTS): $(OBJSDIR)/%.o: $(SRCDIR)/%.cpp $(HEADERS)
 	$(CCX) $(CCXFLAGS) $(INCLUDES) -c $< -o $(OBJSDIR)/$(@F)
 
 $(QPULIB):
-	cd ./include/QPULib && make
+	cd ./include/QPULib && make $(QPUFLAGS)
 
 $(OBJSDIR):
 	mkdir build
@@ -55,13 +63,13 @@ $(OBJSDIR):
 all:
 	make WIRING=1 QPU=1 CAM=1 OPENCV=1
 
+emulation:
+	make WIRING=1 QPUE=1 CAM=1 OPENCV=1
+
 clean:
 	cd ./include/QPULib && make clean
 	rm -f project.out
 	rm -rf $(OBJSDIR)
-	find $(OBJSDIR)/ -name '*.o' -delete
-	find $(DEPDIR)/ -name '*.h.gch' -delete
-	rm -r project.dSYM
 
 run:
 	@echo "------------------------------ Compiling project... ------------------------------"		


### PR DESCRIPTION
Added option to compile with QPULib in emulation mode.

Running "make emulation" will compile the project with all libraries and QPULib in emulation mode. Alternatively the flag "QPUE=1" can be used to include QPULib in emulation mode. Note that "make clean" needs to be ran if QPULib was compiled in non-emulation mode the last time it was compiled.

The preprocessor macro "QPU" shows whether the project is being made with QPULib or not.

Also removed some unnecessary things from make clean.