### PR TITLE
Thread update regulator

### DIFF
--- a/src/update_controller/update_controller.cpp
+++ b/src/update_controller/update_controller.cpp
@@ -1,0 +1,23 @@
+
+#include "update_controller.hpp"
+
+#include <thread>
+
+update_controller::update_controller() : period(DEFAULT_PERIOD) { }
+
+update_controller::update_controller(int64_t _period) : period(_period) {
+}
+
+void update_controller::start() {
+    start_time = std::chrono::steady_clock::now();
+}
+
+void update_controller::wait() {
+    
+    auto update_period = std::chrono::milliseconds(this->period);
+
+    auto wake_up = start_time + std::chrono::duration_cast<std::chrono::steady_clock::duration>(update_period);
+
+    std::this_thread::sleep_until(wake_up);
+
+}

--- a/src/update_controller/update_controller.hpp
+++ b/src/update_controller/update_controller.hpp
@@ -1,0 +1,50 @@
+#ifndef CM_UPDATE_CONTROLLER_H
+#define CM_UPDATE_CONTROLLER_H
+
+#include <cstdint>
+#include <chrono>
+
+/**
+ * Class that regulates the update frequency of running threads to a given
+ * frequency or period
+ */
+class update_controller {
+
+public:
+
+    // The default period
+    const int64_t DEFAULT_PERIOD = 20;
+
+    /**
+     * Default constructor
+     */
+    update_controller();
+
+    /**
+     * Constructor that takes a period
+     * 
+     * @param period The period of the update controller
+     */
+    update_controller(int64_t period);
+
+    /**
+     * Starts the timer of the update controller
+     */
+    void start();
+
+    /**
+     * Blocks the calling thread until period ms has passed since start was called
+     */
+    void wait();
+
+private:
+
+    // The period of the controller
+    int64_t period;
+
+    // The time_point when start() was called
+    std::chrono::steady_clock::time_point start_time;
+
+};
+
+#endif


### PR DESCRIPTION
Implemented the class "update_controller" that helps controlling the refresh rate of a thread. The functions start() and wait() allow for abstracting away the waiting logic.